### PR TITLE
Adjust the way to get the labelContainer width

### DIFF
--- a/controlsfx/src/main/java/impl/org/controlsfx/skin/ToggleSwitchSkin.java
+++ b/controlsfx/src/main/java/impl/org/controlsfx/skin/ToggleSwitchSkin.java
@@ -169,7 +169,7 @@ public class ToggleSwitchSkin extends SkinBase<ToggleSwitch>
         thumbArea.setLayoutX(contentWidth - thumbAreaWidth);
         thumbArea.setLayoutY(thumbAreaY);
 
-        labelContainer.resize(contentWidth - thumbAreaWidth, thumbAreaHeight);
+        labelContainer.resize(label.prefWidth(-1), thumbAreaHeight);
         labelContainer.setLayoutY(thumbAreaY);
 
         if (!toggleSwitch.isSelected())


### PR DESCRIPTION
There is always a gap between label and button when using contentWidth - thumbAreaWidth